### PR TITLE
feat: `all` 日志只分发给 body 中显式出现的包

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -31132,16 +31132,30 @@ function extractChangelog(markdown, pkgNames) {
 		pkgLogs[name] = [];
 	});
 	let collectLogs = false;
+	/** body 中出现的包名 heading（不含 `all`），用于限定 `all` 的分发范围 */
+	const mentionedPkgNames = /* @__PURE__ */ new Set();
+	/** 暂存 `all` 的列表项，两趟处理：先收集中出现的 heading，再分发 */
+	const allListItems = [];
 	md.forEach((token) => {
 		if (token.type === changelogHeading.type && token.depth === changelogHeading.depth) collectLogs = token.text === changelogHeading.text;
-		if (collectLogs && token.type === "heading" && token.depth === pkgDepth) pkgName = token.text;
+		if (collectLogs && token.type === "heading" && token.depth === pkgDepth) {
+			pkgName = token.text;
+			if (pkgName !== "all") mentionedPkgNames.add(pkgName);
+		}
 		if (collectLogs && token.type === "list" && (pkgName === "all" || pkgNames.includes(pkgName))) token.items.forEach((item) => {
 			if (item.type === "list_item" && item.tokens.length) {
 				const token = item.tokens[0];
-				(pkgName === "all" ? pkgNames : [pkgName]).forEach((name) => pkgLogs[name].push(token.text));
+				if (pkgName === "all") allListItems.push(token.text);
+				else pkgLogs[pkgName].push(token.text);
 			}
 		});
 	});
+	if (allListItems.length) {
+		const targetPkgNames = mentionedPkgNames.size > 0 ? pkgNames.filter((n) => mentionedPkgNames.has(n)) : pkgNames;
+		allListItems.forEach((text) => {
+			targetPkgNames.forEach((name) => pkgLogs[name].push(text));
+		});
+	}
 	return pkgLogs;
 }
 /**
@@ -31410,6 +31424,10 @@ function extractTagChangelogLogs(markdown, pkgNames) {
 	let collectLogs = false;
 	let pkgName = "";
 	const logs = [];
+	/** body 中出现的包名 heading（不含 `all`），用于限定 `all` 的分发范围 */
+	const mentionedPkgNames = /* @__PURE__ */ new Set();
+	/** 暂存 `all` 的列表项 */
+	const allListItems = [];
 	md.forEach((token) => {
 		if (token.type === changelogHeading.type && token.depth === changelogHeading.depth) {
 			collectLogs = token.text === changelogHeading.text;
@@ -31418,23 +31436,28 @@ function extractTagChangelogLogs(markdown, pkgNames) {
 		}
 		if (!collectLogs) return;
 		if (token.type === "heading") {
-			if (token.depth === pkgDepth) pkgName = token.text;
-			else collectLogs = false;
+			if (token.depth === pkgDepth) {
+				pkgName = token.text;
+				if (pkgName !== "all") mentionedPkgNames.add(pkgName);
+			} else collectLogs = false;
 			return;
 		}
 		if (token.type === "list") {
 			const items = token.items;
-			if (pkgName === "all" || pkgNames.includes(pkgName) || pkgName === "") {
-				const targetCount = pkgName === "all" ? pkgNames.length : 1;
-				items.forEach((item) => {
-					if (item.type === "list_item" && item.tokens.length) {
-						const text = item.tokens[0].text;
-						for (let i = 0; i < targetCount; i++) logs.push(text);
-					}
-				});
-			}
+			if (pkgName === "all" || pkgNames.includes(pkgName) || pkgName === "") if (pkgName === "all") items.forEach((item) => {
+				if (item.type === "list_item" && item.tokens.length) allListItems.push(item.tokens[0].text);
+			});
+			else items.forEach((item) => {
+				if (item.type === "list_item" && item.tokens.length) logs.push(item.tokens[0].text);
+			});
 		}
 	});
+	if (allListItems.length) {
+		const targetCount = mentionedPkgNames.size > 0 ? pkgNames.filter((n) => mentionedPkgNames.has(n)).length : pkgNames.length;
+		allListItems.forEach((text) => {
+			for (let i = 0; i < targetCount; i++) logs.push(text);
+		});
+	}
 	return logs;
 }
 function isRenderableChangelogLog(log) {
@@ -31668,8 +31691,6 @@ async function confirmPullRequestChangelog(prNumber, prData, token) {
 }
 async function confirmChangelog(prNumber, log, token) {
 	if (!log.startsWith("### 📝 更新日志")) return false;
-	const changelog = extractChangelog(log || "", getInputPkgs());
-	info(`stash_changelog: ${JSON.stringify(changelog, null, 2)}`);
 	const { createPullRequest, getOpenPullRequestByHead, getPullRequestData } = useGithub(token);
 	const prData = await getPullRequestData(prNumber);
 	const { cloneRepo, addRemote, checkoutPr, checkoutBranch, createBranch, gitPush, isNeedCommit } = useGit(token);
@@ -31695,6 +31716,9 @@ async function confirmChangelog(prNumber, log, token) {
 	} else await checkoutBranch(prData.head.ref);
 	const pkgs = getConfiguredPackages(cwd());
 	info(`pkgs: ${JSON.stringify(pkgs, null, 2)}`);
+	const pkgNames = pkgs.map((p) => p.name);
+	const changelog = extractChangelog(log || "", pkgNames.length ? pkgNames : getInputPkgs());
+	info(`stash_changelog: ${JSON.stringify(changelog, null, 2)}`);
 	stashPackageChangelog(prData, pkgs, changelog);
 	await exec("git", ["add", "**/pr-*.md"]);
 	await exec("git", ["status"]);

--- a/fixtures/pull_request_body/pr_body9.md
+++ b/fixtures/pull_request_body/pr_body9.md
@@ -1,0 +1,10 @@
+## ℹ️ 非 TDesign 仓库？请忽略以下内容
+无需填写更新日志
+
+### 📝 更新日志
+#### all
+- feat(Button): New Component
+- chore(utils): add `isString` function
+#### pkg-a
+
+#### pkg-c

--- a/src/github-event/issue-comment.ts
+++ b/src/github-event/issue-comment.ts
@@ -78,9 +78,6 @@ export async function confirmChangelog(prNumber: number, log: string, token: str
   if (!log.startsWith('### 📝 更新日志')) {
     return false
   }
-  const changelog = extractChangelog(log || '', getInputPkgs())
-
-  core.info(`stash_changelog: ${JSON.stringify(changelog, null, 2)}`)
 
   const { createPullRequest, getOpenPullRequestByHead, getPullRequestData } = useGithub(token)
   const prData = await getPullRequestData(prNumber) as PullRequestData
@@ -115,6 +112,11 @@ export async function confirmChangelog(prNumber: number, log: string, token: str
   }
   const pkgs = getConfiguredPackages(cwd())
   core.info(`pkgs: ${JSON.stringify(pkgs, null, 2)}`)
+  const pkgNames = pkgs.map(p => p.name)
+  const changelog = extractChangelog(log || '', pkgNames.length ? pkgNames : getInputPkgs())
+
+  core.info(`stash_changelog: ${JSON.stringify(changelog, null, 2)}`)
+
   stashPackageChangelog(prData, pkgs, changelog)
   await exec('git', ['add', '**/pr-*.md'])
   await exec('git', ['status'])

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -102,6 +102,10 @@ export function extractChangelog(markdown: string, pkgNames: string[]) {
     pkgLogs[name] = []
   })
   let collectLogs = false
+  /** body 中出现的包名 heading（不含 `all`），用于限定 `all` 的分发范围 */
+  const mentionedPkgNames = new Set<string>()
+  /** 暂存 `all` 的列表项，两趟处理：先收集中出现的 heading，再分发 */
+  const allListItems: string[] = []
 
   md.forEach((token) => {
     if (token.type === changelogHeading.type && token.depth === changelogHeading.depth) {
@@ -110,18 +114,34 @@ export function extractChangelog(markdown: string, pkgNames: string[]) {
 
     if (collectLogs && token.type === 'heading' && token.depth === pkgDepth) {
       pkgName = token.text
+      if (pkgName !== 'all') {
+        mentionedPkgNames.add(pkgName)
+      }
     }
     if (collectLogs && token.type === 'list' && (pkgName === 'all' || pkgNames.includes(pkgName))) {
       const items = token.items as Tokens.ListItem[]
       items.forEach((item) => {
         if (item.type === 'list_item' && item.tokens.length) {
           const token = item.tokens[0] as Tokens.Text
-          const targetPkgNames = pkgName === 'all' ? pkgNames : [pkgName]
-          targetPkgNames.forEach(name => pkgLogs[name].push(token.text))
+          if (pkgName === 'all') {
+            allListItems.push(token.text)
+          }
+          else {
+            pkgLogs[pkgName].push(token.text)
+          }
         }
       })
     }
   })
+
+  // 第二趟：将 `all` 中暂存的条目分发到 body 中显式出现的包
+  if (allListItems.length) {
+    const targetPkgNames = mentionedPkgNames.size > 0 ? pkgNames.filter(n => mentionedPkgNames.has(n)) : pkgNames
+    allListItems.forEach((text) => {
+      targetPkgNames.forEach(name => pkgLogs[name].push(text))
+    })
+  }
+
   return pkgLogs
 }
 
@@ -497,6 +517,10 @@ function extractTagChangelogLogs(markdown: string, pkgNames: string[]): string[]
   let collectLogs = false
   let pkgName = ''
   const logs: string[] = []
+  /** body 中出现的包名 heading（不含 `all`），用于限定 `all` 的分发范围 */
+  const mentionedPkgNames = new Set<string>()
+  /** 暂存 `all` 的列表项 */
+  const allListItems: string[] = []
 
   md.forEach((token) => {
     if (token.type === changelogHeading.type && token.depth === changelogHeading.depth) {
@@ -510,6 +534,9 @@ function extractTagChangelogLogs(markdown: string, pkgNames: string[]): string[]
     if (token.type === 'heading') {
       if (token.depth === pkgDepth) {
         pkgName = token.text
+        if (pkgName !== 'all') {
+          mentionedPkgNames.add(pkgName)
+        }
       }
       else {
         // 离开更新日志区块
@@ -520,18 +547,34 @@ function extractTagChangelogLogs(markdown: string, pkgNames: string[]): string[]
     if (token.type === 'list') {
       const items = token.items as Tokens.ListItem[]
       if (pkgName === 'all' || pkgNames.includes(pkgName) || pkgName === '') {
-        const targetCount = pkgName === 'all' ? pkgNames.length : 1
-        items.forEach((item) => {
-          if (item.type === 'list_item' && item.tokens.length) {
-            const text = (item.tokens[0] as Tokens.Text).text
-            for (let i = 0; i < targetCount; i++) {
-              logs.push(text)
+        if (pkgName === 'all') {
+          items.forEach((item) => {
+            if (item.type === 'list_item' && item.tokens.length) {
+              allListItems.push((item.tokens[0] as Tokens.Text).text)
             }
-          }
-        })
+          })
+        }
+        else {
+          items.forEach((item) => {
+            if (item.type === 'list_item' && item.tokens.length) {
+              logs.push((item.tokens[0] as Tokens.Text).text)
+            }
+          })
+        }
       }
     }
   })
+
+  // 第二趟：将 `all` 中暂存的条目按实际出现的包数分发
+  if (allListItems.length) {
+    const targetCount = mentionedPkgNames.size > 0 ? pkgNames.filter(n => mentionedPkgNames.has(n)).length : pkgNames.length
+    allListItems.forEach((text) => {
+      for (let i = 0; i < targetCount; i++) {
+        logs.push(text)
+      }
+    })
+  }
+
   return logs
 }
 

--- a/test/__snapshots__/utils.test.ts.snap
+++ b/test/__snapshots__/utils.test.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`utils > extractChangelog > all 日志只分发给 body 中显式出现的包，缺少 heading 的包不获得 all 条目 1`] = `
+{
+  "pkg-a": [
+    "feat(Button): New Component",
+    "chore(utils): add \`isString\` function",
+  ],
+  "pkg-b": [],
+  "pkg-c": [
+    "feat(Button): New Component",
+    "chore(utils): add \`isString\` function",
+  ],
+}
+`;
+
 exports[`utils > extractChangelog > all 日志应用到所有包 1`] = `
 {
   "pkg-a": [
@@ -7,9 +21,9 @@ exports[`utils > extractChangelog > all 日志应用到所有包 1`] = `
     "chore(utils): add \`isString\` function",
   ],
   "pkg-b": [
+    "fix(link): fix link",
     "feat(Button): New Component",
     "chore(utils): add \`isString\` function",
-    "fix(link): fix link",
   ],
   "pkg-c": [
     "feat(Button): New Component",

--- a/test/issue-comment.test.ts
+++ b/test/issue-comment.test.ts
@@ -57,7 +57,7 @@ vi.mock('../src/utils/common', () => ({
   extractChangelog: mocks.extractChangelog,
   extractReleaseLogs: vi.fn().mockReturnValue([]),
   getChangelogFilePath: (release: { dir: string }, lang: 'zh' | 'en') => `${release.dir}/${lang === 'en' ? 'CHANGELOG.en-US.md' : 'CHANGELOG.md'}`,
-  getConfiguredPackages: () => [],
+  getConfiguredPackages: vi.fn().mockReturnValue([]),
   getInputPkgs: () => ['pkg-a'],
   getPrCommentWhitelist: mocks.getPrCommentWhitelist,
   getPullRequestNumber: () => 42,
@@ -133,6 +133,37 @@ describe('issue_comment', () => {
       { 'pkg-a': ['feat(Button): add loading state'] },
     )
     expect(mocks.cloneRepo).toHaveBeenCalledOnce()
+  })
+
+  it('passes actual disk packages (excluding deleted ones) to extractChangelog when \"all\" is used', async () => {
+    const { getConfiguredPackages } = await import('../src/utils/common')
+    // pkg-b 被删除，磁盘只剩下 pkg-a 和 pkg-c
+    vi.mocked(getConfiguredPackages).mockReturnValue([
+      { name: 'pkg-a', relativeDir: 'packages/pkg-a', type: 'node' as const },
+      { name: 'pkg-c', relativeDir: 'packages/pkg-c', type: 'node' as const },
+    ])
+
+    mocks.context.payload.comment.body = '  /changelog\n'
+
+    await expect(issue_comment('token')).resolves.toBe(true)
+
+    // 第一次调用（confirmPullRequestChangelog）仍然用 getInputPkgs() → ['pkg-a']
+    expect(mocks.extractChangelog).toHaveBeenNthCalledWith(1, prData.body, ['pkg-a'])
+    // 第二次调用（confirmChangelog 修复后）应使用磁盘实际存在的包名 → ['pkg-a', 'pkg-c']
+    expect(mocks.extractChangelog).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      ['pkg-a', 'pkg-c'],
+    )
+    // stashPackageChangelog 也传入来自 getConfiguredPackages 的包列表
+    expect(mocks.stashPackageChangelog).toHaveBeenCalledWith(
+      prData,
+      [
+        { name: 'pkg-a', relativeDir: 'packages/pkg-a', type: 'node' },
+        { name: 'pkg-c', relativeDir: 'packages/pkg-c', type: 'node' },
+      ],
+      expect.any(Object),
+    )
   })
 
   it('ignores unrelated created comments before loading the whitelist', async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -114,6 +114,24 @@ describe('utils', () => {
       expect(log).toMatchSnapshot()
     })
 
+    it('all 日志只分发给 body 中显式出现的包，缺少 heading 的包不获得 all 条目', () => {
+      const packages = getPackages('fixtures/repo2')
+      // pr_body9 有 all + pkg-a + pkg-c，但没有 pkg-b heading
+      const body = readFileSync('fixtures/pull_request_body/pr_body9.md', 'utf8')
+      const log = extractChangelog(body, packages.map(pkg => pkg.name))
+      // pkg-b 没有 heading，all 条目不应发给它
+      expect(log['pkg-a']).toEqual([
+        'feat(Button): New Component',
+        'chore(utils): add `isString` function',
+      ])
+      expect(log['pkg-b']).toEqual([])
+      expect(log['pkg-c']).toEqual([
+        'feat(Button): New Component',
+        'chore(utils): add `isString` function',
+      ])
+      expect(log).toMatchSnapshot()
+    })
+
     // it('本条 PR 不需要纳入 Changelog', () => {
     //   const packages = getPackages('fixtures/repo1')
 


### PR DESCRIPTION
- extractChangelog / extractTagChangelogLogs 改为两趟处理
- `all` 条目只复制给 body 中有 `#### pkgName` heading 的包
- 修改 mode 默认值为 single
- 新增测试及 snapshot